### PR TITLE
add symlink net101.md for people coming from youtube

### DIFF
--- a/net101.md
+++ b/net101.md
@@ -1,0 +1,1 @@
+rx-m-net-101-kubecon-eu-2022.md


### PR DESCRIPTION
I had a 404 when pulling up the URL at the start of the video.
[timestamp where that's visible](https://youtu.be/cUGXu2tiZMc?t=230).
A symlink gives access for those users without breaking things for others who might have bookmarked the new link now